### PR TITLE
Feature/bind player teams

### DIFF
--- a/app/assets/bundle.js
+++ b/app/assets/bundle.js
@@ -6,7 +6,19 @@ require("./../../bower_components/angular-strap/dist/angular-strap.tpl")
 
 var cougar = angular.module('cougar', [])
 
-cougar.controller('PlayersCtrl', function ($scope, $http) {
+cougar.factory('Teams', function ($http) {
+  var teams = { list: [] }
+
+  $http.get('http://localhost:7777/api/teams/').success(function (data) {
+    teams.list = data
+  })
+
+  return teams
+})
+
+cougar.controller('PlayersCtrl', function ($scope, $http, Teams) {
+  $scope.teams = Teams
+
   $scope.addPlayer = function (player) {
     if (player) {
       $http.post('http://localhost:7777/api/players/', player, {headers: {'Content-Type': 'application/json'}})
@@ -14,20 +26,14 @@ cougar.controller('PlayersCtrl', function ($scope, $http) {
         console.log(data)
       })
       .error(function playerCreateError(data) {
-        console.log(data)
+        console.error(data)
       })
     }
   }
 })
 
-cougar.controller('TeamsCtrl', function ($scope, $http) {
-  var updateTeamsList = function () {
-    $http.get('http://localhost:7777/api/teams/').success(function (data) {
-      $scope.teams = data
-    })
-  }
-
-  $scope.teams = updateTeamsList()
+cougar.controller('TeamsCtrl', function ($scope, $http, Teams) {
+  $scope.teams = Teams
 
   $scope.addTeam = function (team) {
     if (team) {
@@ -35,10 +41,10 @@ cougar.controller('TeamsCtrl', function ($scope, $http) {
       .success(function teamCreated(data) {
         console.log(data)
         $scope.team.name = ''
-        updateTeamsList()
+        Teams.list.push(data)
       })
       .error(function teamCreateError(data) {
-        console.log(data)
+        console.error(data)
       })
     }
   }
@@ -46,9 +52,14 @@ cougar.controller('TeamsCtrl', function ($scope, $http) {
   $scope.deleteTeam = function (team) {
     if (team) {
       $http.delete('http://localhost:7777/api/teams/' + team.id)
-      .success(function (data) {
-        console.log(data)
-        updateTeamsList()
+      .success(function teamDeleted(data) {
+        var index = Teams.list.indexOf(team)
+        Teams.list.splice(index, 1)
+
+        console.log('Team' ,team.id, 'was destroyed')
+      })
+      .error(function teamDeleteError(data) {
+        console.error(data)
       })
     }
   }

--- a/app/index.html
+++ b/app/index.html
@@ -27,16 +27,7 @@
         <div class="form-group">
           <label for="player-team">Player Team</label>
           <select type="select" name="player-team" class="form-control" ng-model="player.team">
-            <option value="1">Team 1</option>
-            <option value="2">Team 2</option>
-            <option value="3">Team 3</option>
-            <option value="4">Team 4</option>
-            <option value="5">Team 5</option>
-            <option value="6">Team 6</option>
-            <option value="7">Team 7</option>
-            <option value="8">Team 8</option>
-            <option value="9">Team 9</option>
-            <option value="0">Team 0</option>
+            <option value="{{team.id}}" ng-repeat="team in teams.list">{{team.name}}</option>
           </select>
         </div>
 
@@ -50,7 +41,7 @@
         <h2>Teams</h2>
         <ul class="list-unstyled">
           <li ng-hide="teams">NO TEAMS</li>
-          <li ng-show="teams" ng-repeat="team in teams">
+          <li ng-show="teams" ng-repeat="team in teams.list">
             <span class="glyphicon glyphicon-minus-sign" ng-click="deleteTeam(team)"></span>
             {{team.name}}
           </li>

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -5,7 +5,19 @@ require('angular-strap/dist/angular-strap.tpl')
 
 var cougar = angular.module('cougar', [])
 
-cougar.controller('PlayersCtrl', function ($scope, $http) {
+cougar.factory('Teams', function ($http) {
+  var teams = { list: [] }
+
+  $http.get('http://localhost:7777/api/teams/').success(function (data) {
+    teams.list = data
+  })
+
+  return teams
+})
+
+cougar.controller('PlayersCtrl', function ($scope, $http, Teams) {
+  $scope.teams = Teams
+
   $scope.addPlayer = function (player) {
     if (player) {
       $http.post('http://localhost:7777/api/players/', player, {headers: {'Content-Type': 'application/json'}})
@@ -13,20 +25,14 @@ cougar.controller('PlayersCtrl', function ($scope, $http) {
         console.log(data)
       })
       .error(function playerCreateError(data) {
-        console.log(data)
+        console.error(data)
       })
     }
   }
 })
 
-cougar.controller('TeamsCtrl', function ($scope, $http) {
-  var updateTeamsList = function () {
-    $http.get('http://localhost:7777/api/teams/').success(function (data) {
-      $scope.teams = data
-    })
-  }
-
-  $scope.teams = updateTeamsList()
+cougar.controller('TeamsCtrl', function ($scope, $http, Teams) {
+  $scope.teams = Teams
 
   $scope.addTeam = function (team) {
     if (team) {
@@ -34,10 +40,10 @@ cougar.controller('TeamsCtrl', function ($scope, $http) {
       .success(function teamCreated(data) {
         console.log(data)
         $scope.team.name = ''
-        updateTeamsList()
+        Teams.list.push(data)
       })
       .error(function teamCreateError(data) {
-        console.log(data)
+        console.error(data)
       })
     }
   }
@@ -45,9 +51,14 @@ cougar.controller('TeamsCtrl', function ($scope, $http) {
   $scope.deleteTeam = function (team) {
     if (team) {
       $http.delete('http://localhost:7777/api/teams/' + team.id)
-      .success(function (data) {
-        console.log(data)
-        updateTeamsList()
+      .success(function teamDeleted(data) {
+        var index = Teams.list.indexOf(team)
+        Teams.list.splice(index, 1)
+
+        console.log('Team' ,team.id, 'was destroyed')
+      })
+      .error(function teamDeleteError(data) {
+        console.error(data)
       })
     }
   }

--- a/server.js
+++ b/server.js
@@ -67,6 +67,7 @@ router.get('/api/teams', function serveTeams(req, res) {
 })
 
 router.post('/api/teams', function createTeam(req, res) {
+  req.body.tournament = 1
   Team.forge(req.body).save().then(function teamCreated(team) {
     res.json(team)
   })


### PR DESCRIPTION
Adds a hack that assigns touney id on the backend to 1 since we havent created an api for tournaments.

When new team is added, you can immediately select it from the players teams dropdown in the players card.

This is done through a factory that shares the teams data
